### PR TITLE
Update Clemson faculty and move Zheyu Zhang to RPI

### DIFF
--- a/docs/USA/clemson.markdown
+++ b/docs/USA/clemson.markdown
@@ -5,6 +5,18 @@ permalink: /flying-brochure/clemson
 ---
 # Clemson University
 
+---
+
+[Dingrui Li](https://www.clemson.edu/cecas/departments/ece/faculty_staff/faculty/ldingrui.html)
+
+小 AP，2023年 PhD@UTK Fred Wang的学生，清华大学校友。
+
+曾在 ABB USCRC工作，于 2024年加入 Clemson。
+
+研究领域主要为电力电子在电网中的应用，AI数据中心并网，AI控制在电力电子中的应用等。
+
+---
+
 [Johan H. Enslin](https://www.clemson.edu/cecas/departments/ece/faculty_staff/faculty/jenslin.html)
 
 IEEE Fellow，南非人，1988年 PhD@ Rand Afrikaans University
@@ -12,6 +24,8 @@ IEEE Fellow，南非人，1988年 PhD@ Rand Afrikaans University
 曾在工业界工作 20多年，之后在 UNCC任教，是 UNCC EPIC的创始人。
 
 于 2016年加入 Clemson。研究领域为电网，光伏，智能建筑等。
+
+现为ARPA-E Program Director，暂时不招学生。
 
 ---
 
@@ -23,15 +37,6 @@ IEEE Fellow，南非人，1988年 PhD@ Rand Afrikaans University
 
 研究领域主要为电机 电网等 偏 PS。
 
----
-
-[Zheyu Zhang](https://www.clemson.edu/cecas/departments/ece/faculty_staff/faculty/zzhang.html)
-
-小 AP，2015年 PhD@UTK Fred Wang的学生，华中科技大学校友。
-
-曾在 GE GRC工作，于 2019年加入 Clemson。
-
-研究领域主要为宽禁带半导体应用，储能系统等。
 
 ---
 

--- a/docs/USA/rpi.markdown
+++ b/docs/USA/rpi.markdown
@@ -6,6 +6,11 @@ permalink: /flying-brochure/rpi
 # Rensselaer Polytechnic Institute
 
 ---
+[Zheyu Zhang](https://faculty.rpi.edu/zheyu-zhang)
+大AP，2015年 PhD@UTK Fred Wang的学生，华中科技大学校友。
+曾在 GE GRC工作，2019-2023年在Clemson，2023年跳槽至RPI。
+学术水平扎实，人很nice。研究领域主要为宽禁带半导体应用，半导体可靠性，低温电力电子等。
+---
 [Jian Sun](https://www.ecse.rpi.edu/~jsun/) IEEE Fellow， 1995年 PhD@Paderborn， 南京航空航天大学、北京航空
 航天大学校友， 2017年 Middlebrook奖得主 。研究领域主要为电网， HVDC
 FACTS等，其担任 Director的实验室： [Center for Future Energy Systems (CFES)](http://cfes.rpi.edu/)


### PR DESCRIPTION
Update the Clemson faculty profiles and move Zheyu Zhang's profile from Clemson to RPI in the same change, so the profile remains available at his current institution.

- Add Dingrui Li's profile at Clemson.
- Update Johan H. Enslin's availability.
- Move Zheyu Zhang to RPI with the updated profile and faculty link from #53.

This PR incorporates #53 and supersedes it. Both commits retain Zhou's authorship. Squash merge this PR to record the complete faculty update as one commit.

Validation: only the Clemson and RPI pages change; their contents exactly match the respective original PRs; the combined diff passes whitespace checks.
